### PR TITLE
Declaration of qtype_ordering_test::setUp() must be compatible with T…

### DIFF
--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -41,11 +41,11 @@ class qtype_ordering_test extends advanced_testcase {
     /** @var qtype_ordering instance of the question type class to test. */
     protected $qtype;
 
-    protected function setUp() {
+    protected function setUp(): void {
         $this->qtype = new qtype_ordering();
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         $this->qtype = null;
     }
 


### PR DESCRIPTION
Declaration of qtype_ordering_test::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void
Declaration of qtype_ordering_test::tearDown() must be compatible with PHPUnit\Framework\TestCase::TearDown(): void